### PR TITLE
[ORG] RU-AXAV: Correctly handle parametric pulse assemble() kwarg if empty list (#6922)

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -438,8 +438,8 @@ def _parse_pulse_args(
         if isinstance(rep_time, list):
             rep_time = rep_time[0]
         rep_time = int(rep_time * 1e6)  # convert sec to μs
-
-    parametric_pulses = parametric_pulses or getattr(backend_config, "parametric_pulses", [])
+    if parametric_pulses is None:
+        parametric_pulses = getattr(backend_config, "parametric_pulses", [])
 
     # create run configuration and populate
     run_config_dict = dict(

--- a/qiskit/transpiler/passes/optimization/cx_cancellation.py
+++ b/qiskit/transpiler/passes/optimization/cx_cancellation.py
@@ -29,26 +29,25 @@ class CXCancellation(TransformationPass):
         """
         cx_runs = dag.collect_runs(["cx"])
         for cx_run in cx_runs:
-            # Partition the cx_run into chunks with equal gate arguments
-            partition = []
+            # Although one `cx_run` will always have the same set of qubits,
+            # the order of these qubits matters (CXi_j != CXj_i).
+            # Therefore, we have to partition each run into chunks where the qargs
+            # are in the same order, and only cancel out CXs within each chunk.
+            partitions = []
             chunk = []
             for i in range(len(cx_run) - 1):
                 chunk.append(cx_run[i])
-
-                qargs0 = cx_run[i].qargs
-                qargs1 = cx_run[i + 1].qargs
-
-                if qargs0 != qargs1:
-                    partition.append(chunk)
+                if cx_run[i].qargs != cx_run[i + 1].qargs:
+                    partitions.append(chunk)
                     chunk = []
             chunk.append(cx_run[-1])
-            partition.append(chunk)
-            # Simplify each chunk in the partition
-            for chunk in partition:
+            partitions.append(chunk)
+
+            # Remove an even number of CX gates from each chunk
+            for chunk in partitions:
                 if len(chunk) % 2 == 0:
-                    for n in chunk:
-                        dag.remove_op_node(n)
-                else:
-                    for n in chunk[1:]:
-                        dag.remove_op_node(n)
+                    dag.remove_op_node(chunk[0])
+                for node in chunk[1:]:
+                    dag.remove_op_node(node)
+
         return dag

--- a/qiskit/utils/__init__.py
+++ b/qiskit/utils/__init__.py
@@ -26,6 +26,7 @@ Utilities (:mod:`qiskit.utils`)
    local_hardware_info
    is_main_process
    apply_prefix
+   detach_prefix
 
 Algorithm Utilities
 ===================
@@ -62,7 +63,7 @@ from .deprecation import deprecate_arguments
 from .deprecation import deprecate_function
 from .multiprocessing import local_hardware_info
 from .multiprocessing import is_main_process
-from .units import apply_prefix
+from .units import apply_prefix, detach_prefix
 
 from .circuit_utils import summarize_circuits
 from .entangler_map import get_entangler_map, validate_entangler_map

--- a/qiskit/utils/units.py
+++ b/qiskit/utils/units.py
@@ -12,8 +12,14 @@
 
 """SI unit utilities"""
 
+from typing import Tuple, Optional, Union
 
-def apply_prefix(value: float, unit: str) -> float:
+import numpy as np
+
+from qiskit.circuit.parameterexpression import ParameterExpression
+
+
+def apply_prefix(value: Union[float, ParameterExpression], unit: str) -> float:
     """
     Given a SI unit prefix and value, apply the prefix to convert to
     standard SI unit.
@@ -25,16 +31,114 @@ def apply_prefix(value: float, unit: str) -> float:
     Returns:
         Converted value.
 
+    .. note::
+
+        This may induce tiny value error due to internal representation of float object.
+        See https://docs.python.org/3/tutorial/floatingpoint.html for details.
+
     Raises:
-        Exception: If the units aren't recognized.
+        ValueError: If the ``units`` aren't recognized.
     """
-    downfactors = {"p": 1e12, "n": 1e9, "u": 1e6, "µ": 1e6, "m": 1e3}
-    upfactors = {"k": 1e3, "M": 1e6, "G": 1e9}
-    if not unit:
+    prefactors = {
+        "f": -15,
+        "p": -12,
+        "n": -9,
+        "u": -6,
+        "µ": -6,
+        "m": -3,
+        "k": 3,
+        "M": 6,
+        "G": 9,
+        "T": 12,
+        "P": 15,
+    }
+
+    if not unit or len(unit) == 1:
+        # for example, "m" can represent meter
         return value
-    if unit[0] in downfactors:
-        return value / downfactors[unit[0]]
-    elif unit[0] in upfactors:
-        return value * upfactors[unit[0]]
+
+    if unit[0] not in prefactors:
+        raise ValueError(f"Could not understand unit: {unit}")
+
+    pow10 = prefactors[unit[0]]
+
+    # to avoid round-off error of prefactor
+    if pow10 < 0:
+        return value / pow(10, -pow10)
+
+    return value * pow(10, pow10)
+
+
+def detach_prefix(value: float, decimal: Optional[int] = None) -> Tuple[float, str]:
+    """
+    Given a SI unit value, find the most suitable prefix to scale the value.
+
+    For example, the ``value = 1.3e8`` will be converted into a tuple of ``(130.0, "M")``,
+    which represents a scaled value and auxiliary unit that may be used to display the value.
+    In above example, that value might be displayed as ``130 MHz`` (unit is arbitrary here).
+
+    Example:
+
+        >>> value, prefix = detach_prefix(1e4)
+        >>> print(f"{value} {prefix}Hz")
+        10 kHz
+
+    Args:
+        value: The number to find prefix.
+        decimal: Optional. An arbitrary integer number to represent a precision of the value.
+            If specified, it tries to round the mantissa and adjust the prefix to rounded value.
+            For example, 999_999.91 will become 999.9999 k with ``decimal=4``,
+            while 1.0 M with ``decimal=3`` or less.
+
+    Returns:
+        A tuple of scaled value and prefix.
+
+    .. note::
+
+        This may induce tiny value error due to internal representation of float object.
+        See https://docs.python.org/3/tutorial/floatingpoint.html for details.
+
+    Raises:
+        ValueError: If the ``value`` is out of range.
+        ValueError: If the ``value`` is not real number.
+    """
+    prefactors = {
+        -15: "f",
+        -12: "p",
+        -9: "n",
+        -6: "µ",
+        -3: "m",
+        0: "",
+        3: "k",
+        6: "M",
+        9: "G",
+        12: "T",
+        15: "P",
+    }
+
+    if not np.isreal(value):
+        raise ValueError(f"Input should be real number. Cannot convert {value}.")
+
+    if np.abs(value) != 0:
+        pow10 = int(np.floor(np.log10(np.abs(value)) / 3) * 3)
     else:
-        raise Exception(f"Could not understand units: {unit}")
+        pow10 = 0
+
+    # to avoid round-off error of prefactor
+    if pow10 > 0:
+        mant = value / pow(10, pow10)
+    else:
+        mant = value * pow(10, -pow10)
+
+    if decimal is not None:
+        # Corner case handling
+        # For example, 999_999.99 can be rounded to 1000.0 k rather than 1.0 M.
+        mant = np.round(mant, decimal)
+        if mant >= 1000:
+            mant /= 1000
+            pow10 += 3
+
+    if pow10 not in prefactors:
+        raise ValueError(f"Value is out of range: {value}")
+
+    return mant, prefactors[pow10]

--- a/releasenotes/notes/add-detach-prefix-088e96b88ba29927.yaml
+++ b/releasenotes/notes/add-detach-prefix-088e96b88ba29927.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Add utility function :py:func:`~qiskit.utils.units.detach_prefix` that is a counterpart of
+    :py:func:`~qiskit.utils.units.apply_prefix`.
+    The new function returns a tuple of scaled value and prefix from a given float value.
+    For example, a value ``1.3e8`` will be converted into ``(130, "M")`` that can be
+    used to display a value in the user friendly format, such as `130 MHz`.

--- a/releasenotes/notes/fix-assemble-parametric-pulse-eea8fba73c56a69f.yaml
+++ b/releasenotes/notes/fix-assemble-parametric-pulse-eea8fba73c56a69f.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Fixed an issue with the :func:`~qiskit.compiler.assemble` function when
+    called with the ``backend`` kwarg set and the ``parametric_pulses`` kwarg
+    was set to an empty list the output qobj would contain the
+    ``parametric_pulses`` setting from the given backend's
+    :class:`~qiskit.providers.models.BackendConfiguration` instead of the
+    expected empty list.
+    Fixed `#6898 <https://github.com/Qiskit/qiskit-terra/issues/6898>`__

--- a/test/python/compiler/test_assembler.py
+++ b/test/python/compiler/test_assembler.py
@@ -1318,6 +1318,36 @@ class TestPulseAssembler(QiskitTestCase):
         qobj_insts = qobj.experiments[0].instructions
         self.assertFalse(hasattr(qobj_insts[0], "pulse_shape"))
 
+    def test_assemble_parametric_pulse_kwarg_with_backend_setting(self):
+        """Test that parametric pulses respect the kwarg over backend"""
+        backend = FakeAlmaden()
+
+        qc = QuantumCircuit(1, 1)
+        qc.x(0)
+        qc.measure(0, 0)
+        with pulse.build(backend, name="x") as x_q0:
+            pulse.play(pulse.Gaussian(duration=128, amp=0.1, sigma=16), pulse.drive_channel(0))
+
+        qc.add_calibration("x", (0,), x_q0)
+
+        qobj = assemble(qc, backend, parametric_pulses=["gaussian"])
+        self.assertEqual(qobj.config.parametric_pulses, ["gaussian"])
+
+    def test_assemble_parametric_pulse_kwarg_empty_list_with_backend_setting(self):
+        """Test that parametric pulses respect the kwarg as empty list over backend"""
+        backend = FakeAlmaden()
+
+        qc = QuantumCircuit(1, 1)
+        qc.x(0)
+        qc.measure(0, 0)
+        with pulse.build(backend, name="x") as x_q0:
+            pulse.play(pulse.Gaussian(duration=128, amp=0.1, sigma=16), pulse.drive_channel(0))
+
+        qc.add_calibration("x", (0,), x_q0)
+
+        qobj = assemble(qc, backend, parametric_pulses=[])
+        self.assertEqual(qobj.config.parametric_pulses, [])
+
     def test_init_qubits_default(self):
         """Check that the init_qubits=None assemble option is passed on to the qobj."""
         qobj = assemble(self.schedule, self.backend)

--- a/test/python/transpiler/test_cx_cancellation.py
+++ b/test/python/transpiler/test_cx_cancellation.py
@@ -42,6 +42,81 @@ class TestCXCancellation(QiskitTestCase):
         pass_manager = PassManager()
         pass_manager.append(CXCancellation())
         out_circuit = pass_manager.run(circuit)
-        resources_after = out_circuit.count_ops()
 
-        self.assertNotIn("cx", resources_after)
+        expected = QuantumCircuit(qr)
+        expected.h(qr[0])
+        expected.h(qr[0])
+
+        self.assertEqual(out_circuit, expected)
+
+    def test_pass_cx_cancellation_intermixed_ops(self):
+        """Cancellation shouldn't be affected by the order of ops on different qubits."""
+        qr = QuantumRegister(4)
+        circuit = QuantumCircuit(qr)
+        circuit.h(qr[0])
+        circuit.h(qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[2], qr[3])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[2], qr[3])
+
+        pass_manager = PassManager()
+        pass_manager.append(CXCancellation())
+        out_circuit = pass_manager.run(circuit)
+
+        expected = QuantumCircuit(qr)
+        expected.h(qr[0])
+        expected.h(qr[1])
+
+        self.assertEqual(out_circuit, expected)
+
+    def test_pass_cx_cancellation_chained_cx(self):
+        """Include a test were not all operations can be cancelled."""
+        qr = QuantumRegister(4)
+        circuit = QuantumCircuit(qr)
+        circuit.h(qr[0])
+        circuit.h(qr[1])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[1], qr[2])
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[2], qr[3])
+        circuit.cx(qr[2], qr[3])
+
+        pass_manager = PassManager()
+        pass_manager.append(CXCancellation())
+        out_circuit = pass_manager.run(circuit)
+
+        expected = QuantumCircuit(qr)
+        expected.h(qr[0])
+        expected.h(qr[1])
+        expected.cx(qr[0], qr[1])
+        expected.cx(qr[1], qr[2])
+        expected.cx(qr[0], qr[1])
+
+        self.assertEqual(out_circuit, expected)
+
+    def test_swapped_cx(self):
+        """Test that CX isn't cancelled if there are intermediary ops."""
+        qr = QuantumRegister(4)
+        circuit = QuantumCircuit(qr)
+        circuit.cx(qr[1], qr[0])
+        circuit.swap(qr[1], qr[2])
+        circuit.cx(qr[1], qr[0])
+
+        pass_manager = PassManager()
+        pass_manager.append(CXCancellation())
+        out_circuit = pass_manager.run(circuit)
+        self.assertEqual(out_circuit, circuit)
+
+    def test_inverted_cx(self):
+        """Test that CX order dependence is respected."""
+        qr = QuantumRegister(4)
+        circuit = QuantumCircuit(qr)
+        circuit.cx(qr[0], qr[1])
+        circuit.cx(qr[1], qr[0])
+        circuit.cx(qr[0], qr[1])
+
+        pass_manager = PassManager()
+        pass_manager.append(CXCancellation())
+        out_circuit = pass_manager.run(circuit)
+        self.assertEqual(out_circuit, circuit)

--- a/test/python/utils/__init__.py
+++ b/test/python/utils/__init__.py
@@ -1,0 +1,13 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Qiskit utilities tests."""

--- a/test/python/utils/test_units.py
+++ b/test/python/utils/test_units.py
@@ -1,0 +1,133 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test for unit conversion functions."""
+
+from ddt import ddt, data
+
+from qiskit.test import QiskitTestCase
+from qiskit.utils import apply_prefix, detach_prefix
+
+
+@ddt
+class TestUnitConversion(QiskitTestCase):
+    """Test the unit conversion utilities."""
+
+    def test_apply_prefix(self):
+        """Test applying prefix to value."""
+        ref_values = [
+            ([1.0, "THz"], 1e12),
+            ([1.0, "GHz"], 1e9),
+            ([1.0, "MHz"], 1e6),
+            ([1.0, "kHz"], 1e3),
+            ([1.0, "mHz"], 1e-3),
+            ([1.0, "µHz"], 1e-6),
+            ([1.0, "uHz"], 1e-6),
+            ([1.0, "nHz"], 1e-9),
+            ([1.0, "pHz"], 1e-12),
+        ]
+
+        for args, ref_ret in ref_values:
+            self.assertEqual(apply_prefix(*args), ref_ret)
+
+    def test_not_convert_meter(self):
+        """Test not apply prefix to meter."""
+        self.assertEqual(apply_prefix(1.0, "m"), 1.0)
+
+    def test_detach_prefix(self):
+        """Test detach prefix from the value."""
+        ref_values = [
+            (1e12, (1.0, "T")),
+            (1e11, (100.0, "G")),
+            (1e10, (10.0, "G")),
+            (1e9, (1.0, "G")),
+            (1e8, (100.0, "M")),
+            (1e7, (10.0, "M")),
+            (1e6, (1.0, "M")),
+            (1e5, (100.0, "k")),
+            (1e4, (10.0, "k")),
+            (1e3, (1.0, "k")),
+            (100, (100.0, "")),
+            (10, (10.0, "")),
+            (1.0, (1.0, "")),
+            (0.1, (100.0, "m")),
+            (0.01, (10.0, "m")),
+            (1e-3, (1.0, "m")),
+            (1e-4, (100.0, "µ")),
+            (1e-5, (10.0, "µ")),
+            (1e-6, (1.0, "µ")),
+            (1e-7, (100.0, "n")),
+            (1e-8, (10.0, "n")),
+            (1e-9, (1.0, "n")),
+            (1e-10, (100.0, "p")),
+            (1e-11, (10.0, "p")),
+            (1e-12, (1.0, "p")),
+        ]
+
+        for arg, ref_rets in ref_values:
+            self.assertTupleEqual(detach_prefix(arg), ref_rets)
+
+    def test_detach_prefix_with_zero(self):
+        """Test detach prefix by input zero."""
+        self.assertTupleEqual(detach_prefix(0.0), (0.0, ""))
+
+    def test_detach_prefix_with_negative(self):
+        """Test detach prefix by input negative values."""
+        self.assertTupleEqual(detach_prefix(-1.234e7), (-12.34, "M"))
+
+    def test_detach_prefix_with_value_too_large(self):
+        """Test detach prefix by input too large value."""
+        with self.assertRaises(Exception):
+            self.assertTupleEqual(detach_prefix(1e20), (1e20, ""))
+
+    def test_detach_prefix_with_value_too_small(self):
+        """Test detach prefix by input too small value."""
+        with self.assertRaises(Exception):
+            self.assertTupleEqual(detach_prefix(1e-20), (1e-20, ""))
+
+    def test_rounding(self):
+        """Test detach prefix with decimal specification."""
+        ret = detach_prefix(999_999.991)
+        self.assertTupleEqual(ret, (999.999991, "k"))
+
+        ret = detach_prefix(999_999.991, decimal=4)
+        self.assertTupleEqual(ret, (1.0, "M"))
+
+        ret = detach_prefix(999_999.991, decimal=5)
+        self.assertTupleEqual(ret, (999.99999, "k"))
+
+    @data(
+        -20.791378538739863,
+        9.242757760406565,
+        2.7366806276451543,
+        9.183776167253349,
+        7.658091886606501,
+        -12.21553566621071,
+        8.914055281578145,
+        1.2518807770035825,
+        -6.652899195646036,
+        -4.647159596697976,
+    )
+    def test_get_same_value_after_attach_detach(self, value: float):
+        """Test if same value can be obtained."""
+        unit = "Hz"
+
+        for prefix in ["P", "T", "G", "k", "m", "µ", "n", "p", "f"]:
+            scaled_val = apply_prefix(value, prefix + unit)
+            test_val, ret_prefix = detach_prefix(scaled_val)
+            self.assertAlmostEqual(test_val, value)
+            self.assertEqual(prefix, ret_prefix)
+
+    def test_get_symbol_mu(self):
+        """Test if µ is returned rather than u."""
+        _, prefix = detach_prefix(3e-6)
+        self.assertEqual(prefix, "µ")


### PR DESCRIPTION
This commit fixes an issue with the assemble() function. If the
parametric_pulses kwarg was set to an empty list the assemble function
was incorrectly treating this as if no parametric pulse kwarg was set.
This would result in the incorrect qobj being generated by assemble()
including any parametric pulses given for a provided backend instead of
the expected empty list. This commit fixes the issue by correcting the
logic in assemble() so we only use the backends value if the kwarg is
not set, not when the kwarg evals to False (which was the bug).

Fixes #6898

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


